### PR TITLE
Allow configurable number of randomly placed agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ example:
 
 If the specified file cannot be read, the scripts raise a clear error message.
 
-`single_path.py` randomly chooses six start/goal pairs from the map and runs A*
-between each pair.  When executed it opens a Matplotlib window and animates all
-six agents moving along their computed paths, each agent shown in a different
-color with a numbered label inside a larger marker.  A legend in the plot maps
-each color to its corresponding agent number.
+`single_path.py` samples random start/goal pairs from the map and runs A* for
+each agent. The number of agents defaults to six but can be changed with the
+`--agents` command-line option.  When executed it opens a Matplotlib window and
+animates all agents moving along their computed paths, each agent shown in a
+different color with a numbered label inside a larger marker.


### PR DESCRIPTION
## Summary
- generate start/goal pairs randomly from free grid cells
- allow callers to choose the number of agents and an optional random seed
- document agent-count flag in README

## Testing
- `python -m py_compile single_path.py`
- `python single_path.py --agents 2 --save /tmp/test.gif` (fails: No module named 'matplotlib')
- `pip install matplotlib pillow` (proxy 403)


------
https://chatgpt.com/codex/tasks/task_e_68b154478ec8832e96dbb50abdd42d0b